### PR TITLE
Adding Dockerfile for easy use of pconsc4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.7-slim
+
+# Prevents .pyc file generation in the container
+ENV PYTHONDONTWRITEBYTECODE=1  
+# Turns off buffering for easier container logging
+ENV PYTHONUNBUFFERED=1  
+
+# install relevant packages to env (e.g. git)
+RUN apt-get -y update \
+    && apt-get install --reinstall -y build-essential \
+    &&  apt-get install -y gcc
+
+# Install pip requirements for python
+COPY requirements.txt .
+RUN python -m pip install --no-cache-dir -r requirements.txt \
+    && python -m pip install --no-cache-dir --no-input pconsc4 \
+    && rm requirements.txt
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # PconsC4:
 Fast, accurate, and hassle-free contact prediction.
 
+## Installation with Docker
+To create a minimal python environment containing pconsc4, run the below command in a directory containing the `Dockerfile` (note, the docker engine must be installed).
+```bash
+docker build -t pconsc4 .
+```
+
+Once created, you can enter a simple shell session using the below command. The installation can be confirmed by running `python3` and importing the `pconsc4` library.
+```bash
+docker run --rm -it pconsc4
+```
+
 ## Installation instructions:
 
     pip3 install numpy Cython pythran &&

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-numpy
+h5py==2.10.0
+keras==2.2.4
+tensorflow >=1.12,<2.0
+pythran==0.9.5
+beniget==0.2.1 
+gast==0.3.3
 Cython
-scipy
-keras
-pyGaussDCA
-h5py
+numpy


### PR DESCRIPTION
Hi all, due to open issues #5 #6 and #7  I created this minimal Dockerfile example which allows for a simple python environment to be set up containing a running version of the `pconsc4` library.

I've also added instructions for how to use in the README file.